### PR TITLE
Working user registration, fixed errors in HashedPassword

### DIFF
--- a/src/api.php
+++ b/src/api.php
@@ -15,7 +15,7 @@ $c = $app->getContainer();
 // Setup Eloquent
 $capsule = new \Illuminate\Database\Capsule\Manager;
 $capsule->addConnection($settings['settings']['eloquent']);
-use Illuminate\Container\Container;
+use \Illuminate\Container\Container;
 $capsule->setAsGlobal();
 $capsule->bootEloquent();
 

--- a/src/lib/Field.php
+++ b/src/lib/Field.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Uomi;
+
+use \Respect\Validation\Validator;
+
+class Field {
+
+	public $humanName;
+	public $name;
+	public $isRequired;
+	public $validator;
+
+	protected function __construct($humanName = 'Untitled', $name = 'untitled', $isRequired = false, $validator = null) {
+		$this->humanName = $humanName;
+		$this->name = $name;
+		$this->isRequired = $isRequired;
+		$this->validator = $validator;
+	}
+
+	public static function make(): Field {
+		return new Field();
+	}
+
+	function name(string $humanName, string $name): Field {
+		return new Field($humanName, $name, $this->isRequired, $this->validator);
+	}
+
+	function required(): Field {
+		return new Field($this->humanName, $this->name, true);
+	}
+
+	function optional(): Field {
+		return new Field($this->humanName, $this->name, false);
+	}
+
+	function validated(Validator $v): Field {
+		return new Field($this->humanName, $this->name, $this->isRequired, $v->setName($this->name));
+	}
+}

--- a/src/lib/Form.php
+++ b/src/lib/Form.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Uomi;
+
+use \Respect\Validation\Validator;
+use \Respect\Validation\Exceptions\ValidationException;
+use \Respect\Validation\Exceptions\NestedValidationException;
+
+class Form {
+
+	private $name;
+	private $fields;
+	private $errors;
+
+	function __construct(string $name) {
+		$this->name = $name;
+		$this->fields = [];
+		$this->errors = [];
+	}
+
+	public function addField(Field $field) {
+		array_push($this->fields, $field);
+	}
+
+	public function submit(array $data): array {
+		$isGood = true;
+		$result = [];
+		foreach ($this->fields as $field) {
+
+			if(isset($data[$field->name]) && isset($field->validator)) {
+				// The field is set and it should be validated.
+				try {
+					$field->validator->assert($data[$field->name]);
+				} catch(NestedValidationException $exception) {
+					$isGood = false;
+					$this->errors = array_merge($this->errors, $exception->getMessages());
+				}
+			}
+
+			if(isset($data[$field->name])) {
+				// The field is set, whether or not it needs validation.
+				$result[$field->name] = $data[$field->name];
+
+			} elseif(!isset($data[$field->name]) && $field->isRequired) {
+				// The field is unset and is required.
+				$isGood = false;
+				array_push($this->errors, "$field->name is a required field.");
+			} else {
+				// unset, and optional. Do nothing.
+			}
+		}
+
+		if($isGood) {
+			return $result;
+		} else {
+			throw new \RuntimeException('There was an error in the submitted information.');
+		}
+	}
+
+	public function getErrors(): array {
+		return $this->errors;
+	}
+
+}

--- a/src/lib/HashedPassword.php
+++ b/src/lib/HashedPassword.php
@@ -36,7 +36,7 @@ class HashedPassword {
 
     // generateSalt() -> string
     private function generateSalt(): string {
-        $salt = openssl_random_pseudo_bytes(32);
+        $salt = random_bytes(32);
         $salt = bin2hex($salt);
         return $salt;
     }

--- a/src/lib/controller/SessionController.php
+++ b/src/lib/controller/SessionController.php
@@ -10,7 +10,7 @@ use \Illuminate\Database\Eloquent\ModelNotFoundException;
 
 // ROUTES
 $this->group('/sessions', function() {
-    // $this->get('/{user_id}', '\Uomi\UserController:getUserHandler');
+	$this->post('/', '\Uomi\SessionController:postSessionCollectionHandler');
 });
 
 class SessionController {

--- a/src/lib/factory/UserFactory.php
+++ b/src/lib/factory/UserFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Uomi\Factory;
+
+use \Slim\Container;
+
+use \Respect\Validation\Validator as v;
+use \Respect\Validation\Exceptions\ValidationException;
+use \Respect\Validation\Exceptions\NestedValidationException;
+
+use \Uomi\Status;
+use \Uomi\Model\User;
+use \Uomi\HashedPassword;
+
+class UserFactory {
+
+	private $container;
+
+	private $errors;
+
+	function __construct(Container $c) {
+		$this->container = $c;
+		$this->errors = [];
+	}
+
+	public function submitUserRegistrationForm(array $data): User {
+		$form = self::makeForm();
+		$formResult = [];
+
+		// Validate the form
+		try {
+			$formResult = $form->submit($data);
+		} catch(\RuntimeException $e) {
+			$this->errors = array_merge($this->errors, $form->getErrors());
+			throw $e;
+		}
+
+		// Create the user
+		$user = $this->create($formResult['email'], $formResult['password']); // throws
+		$user->save();
+		return $user;
+	}
+
+	public function create(string $email, string $plainTextPassword): User {
+
+		// CONFLICT CHECKS
+		if($exists = \Uomi\Model\User::where('email',$email)->first()) {
+			$esc = htmlspecialchars($email);
+			$this->errors = ["The email $esc is already in use."];
+			throw new \RuntimeException();
+		}
+
+		// CREATION
+		$user = new User();
+		$user->email = $email;
+		$user->password = HashedPassword::makeFromPlainText($plainTextPassword);
+		// $crypto = new HashedPassword($plainTextPassword);
+		// $user->password = $crypto->getHash();
+		// $user->salt = $crypto->getSalt();
+		return $user;
+	}
+
+	public function getErrors(): array {
+		return $this->errors;
+	}
+
+	public static function makeForm(): \Uomi\Form {
+		$emailValidator = v::notEmpty()->email()->setName('Email');
+		$passwordValidator = v::notEmpty()->length(8, null)->setName('Password');
+		$form = new \Uomi\Form('User Registration');
+		$form->addField(
+			\Uomi\Field::make()->name('Email', 'email')->required()->validated($emailValidator)
+		);
+		$form->addField(
+			\Uomi\Field::make()->name('Password', 'password')->required()->validated($passwordValidator)
+		);
+		return $form;
+	}
+
+}

--- a/src/lib/model/User.php
+++ b/src/lib/model/User.php
@@ -1,5 +1,7 @@
 <?php
-namespace \Uomi\Model;
+namespace Uomi\Model;
+
+use \Uomi\HashedPassword;
 
 class User extends \Illuminate\Database\Eloquent\Model {
 
@@ -9,7 +11,7 @@ class User extends \Illuminate\Database\Eloquent\Model {
         return HashedPassword::withHash($value, $this->salt);
     }
 
-	public function setFirstNameAttribute(HashedPassword $value) {
+	public function setPasswordAttribute(HashedPassword $value) {
 		$this->attributes['password'] = $value->getHash();
 		$this->attributes['salt'] = $value->getSalt();
 	}


### PR DESCRIPTION
There were lots of errors in `\Uomi\HashedPassword`. I fixed them and added some necessary form processing tools, `\Uomi\Form` and `\Uomi\Field`. Documentation on these is forthcoming. The `POST /api/users/` route works now and adds a `User` to the database with a hashed password, a salt, and everything.